### PR TITLE
[scramjet/core+runway] Fix handling of link headers 

### DIFF
--- a/packages/scramjet/packages/core/src/client/shared/requests/xmlhttprequest.ts
+++ b/packages/scramjet/packages/core/src/client/shared/requests/xmlhttprequest.ts
@@ -158,6 +158,6 @@ export default function (client: ScramjetClient, self: Self) {
 export function unrewriteLinkHeader(header: string, context: ScramjetContext) {
 	return header.replace(
 		/<([^>]+)>/gi,
-		(match) => `${unrewriteUrl(match, context)}`
+		(_match, p1) => `<${unrewriteUrl(p1, context)}>`
 	);
 }

--- a/packages/scramjet/packages/core/src/fetch/index.ts
+++ b/packages/scramjet/packages/core/src/fetch/index.ts
@@ -507,10 +507,9 @@ function rewriteLinkHeader(
 	context: ScramjetContext,
 	meta: URLMeta
 ) {
-	return link.replace(
-		/<([^>]+)>/gi,
-		(match) => `<${rewriteUrl(match, context, meta)}>`
-	);
+	return link.replace(/<([^>]+)>/gi, (_match, p1) => {
+		return `<${rewriteUrl(p1, context, meta)}>`;
+	});
 }
 
 export async function rewriteHeaders(

--- a/packages/scramjet/packages/runway/src/inspect.ts
+++ b/packages/scramjet/packages/runway/src/inspect.ts
@@ -63,7 +63,16 @@ async function main() {
 	// Start all matching tests (only basicTests need servers)
 	for (const test of tests) {
 		if (!test.playwrightFn) {
-			await test.start();
+			await test.start({
+				pass: async (message?: string, details?: any) => {
+					console.log(`\n✅ Test passed${message ? `: ${message}` : ""}`);
+					if (details) console.log("   Details:", details);
+				},
+				fail: async (message?: string, details?: any) => {
+					console.log(`\n❌ Test failed${message ? `: ${message}` : ""}`);
+					if (details) console.log("   Details:", details);
+				},
+			});
 			console.log(
 				`🌐 Test "${test.name}" running at http://localhost:${test.port}/`
 			);

--- a/packages/scramjet/packages/runway/src/tests/linkheader.ts
+++ b/packages/scramjet/packages/runway/src/tests/linkheader.ts
@@ -90,4 +90,41 @@ export default [
 			});
 		},
 	}),
+	serverTest({
+		name: "linkheader-next-prev-xhr",
+		start: async (server, port) => {
+			const link = `<http://localhost:${port}/page2>; rel="next", <http://localhost:${port}/page0>; rel="prev"`;
+			server.on("request", (req, res) => {
+				if (req.url === "/") {
+					res.writeHead(200, {
+						"Content-Type": "text/html",
+					});
+					res.end(`
+                    <script>
+                        const xhr = new XMLHttpRequest();
+                        xhr.open("GET", "/page1");
+                        xhr.onload = () => {
+                            let next = xhr.getResponseHeader("Link");
+                            const expected = '${link}';
+                            if (next === expected) {
+                                __testPass("next link header is correct (xhr)");
+                            } else {
+                                __testFail("next link header is incorrect (xhr)", { actual: next, expected: expected });
+                            }
+                        };
+                        xhr.send();
+                    </script>
+                    `);
+				} else if (req.url === "/page1") {
+					res.writeHead(200, {
+						Link: link,
+					});
+					res.end("Page 1");
+				} else {
+					res.writeHead(404);
+					res.end("Not found");
+				}
+			});
+		},
+	}),
 ];

--- a/packages/scramjet/packages/runway/src/tests/linkheader.ts
+++ b/packages/scramjet/packages/runway/src/tests/linkheader.ts
@@ -23,4 +23,71 @@ export default [
 			});
 		},
 	}),
+	serverTest({
+		name: "linkheader-multiple-preloads",
+		start: async (server, port, { pass, fail }) => {
+			const loaded = new Set<string>();
+			server.on("request", (req, res) => {
+				if (req.url === "/") {
+					res.writeHead(200, {
+						"Content-Type": "text/html",
+						Link: `<http://localhost:${port}/script1.js>; rel="preload"; as="script", <http://localhost:${port}/script2.js>; rel="preload"; as="script"`,
+					});
+					res.end();
+				} else if (req.url === "/script1.js") {
+					loaded.add("script1");
+					res.writeHead(200, { "Content-Type": "application/javascript" });
+					res.end("console.log('script1');");
+					if (loaded.size === 2) {
+						pass("both scripts preloaded");
+					}
+				} else if (req.url === "/script2.js") {
+					loaded.add("script2");
+					res.writeHead(200, { "Content-Type": "application/javascript" });
+					res.end("console.log('script2');");
+					if (loaded.size === 2) {
+						pass("both scripts preloaded");
+					}
+				} else {
+					res.writeHead(404);
+					res.end("Not found");
+					fail(`unexpected url request: ${req.url}`);
+				}
+			});
+		},
+	}),
+	serverTest({
+		name: "linkheader-next-prev",
+		start: async (server, port) => {
+			const link = `<http://localhost:${port}/page2>; rel="next", <http://localhost:${port}/page0>; rel="prev"`;
+			server.on("request", (req, res) => {
+				if (req.url === "/") {
+					res.writeHead(200, {
+						"Content-Type": "text/html",
+					});
+					res.end(`
+                    <script>
+                        fetch("/page1").then(res => {
+                            let next = res.headers.get("Link");
+                            const expected = '${link}';
+                            if (next === expected) {
+                                __testPass("next link header is correct");
+                            } else {
+                                __testFail("next link header is incorrect", { actual: next, expected: expected });
+                            }
+                        });
+                    </script>
+                    `);
+				} else if (req.url === "/page1") {
+					res.writeHead(200, {
+						Link: link,
+					});
+					res.end("Page 1");
+				} else {
+					res.writeHead(404);
+					res.end("Not found");
+				}
+			});
+		},
+	}),
 ];

--- a/packages/scramjet/packages/runway/src/tests/linkheader.ts
+++ b/packages/scramjet/packages/runway/src/tests/linkheader.ts
@@ -1,0 +1,26 @@
+import { serverTest } from "../testcommon.ts";
+
+export default [
+	serverTest({
+		name: "linkheader-preload",
+		start: async (server, port, { pass, fail }) => {
+			server.on("request", (req, res) => {
+				if (req.url === "/") {
+					res.writeHead(200, {
+						"Content-Type": "text/html",
+						Link: `<http://localhost:${port}/script.js>; rel="preload"; as="script"`,
+					});
+					res.end();
+				} else if (req.url === "/script.js") {
+					console.log("script.js loaded");
+					pass("script.js loaded");
+				} else {
+					console.log("unexpected url request", req.url);
+					res.writeHead(404);
+					res.end("Not found");
+					fail("unexpected url request");
+				}
+			});
+		},
+	}),
+];


### PR DESCRIPTION
Fix: (un)rewriteLinkUrl now uses proper regex to extract the actual link, stopping invalid requests from being made

tests added to ensure this behavior works

test harness now supports directly passing/failing a test from the server side